### PR TITLE
산책 기록 페이지 개발

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:wooyoungsoo/screens/main_screen.dart';
 import 'package:wooyoungsoo/screens/my_page_screen.dart';
 import 'package:wooyoungsoo/screens/nearby_facility_screen.dart';
 import 'package:wooyoungsoo/screens/signup_screen.dart';
+import 'package:wooyoungsoo/screens/walk_log_screen.dart';
 
 void main() async {
   Provider.debugCheckInvalidValueType = null;
@@ -53,6 +54,7 @@ class MyApp extends StatelessWidget {
         "/activity": (context) => const ActivityScreen(),
         "/mypage": (context) => const MypageScreen(),
         "/nearby": (context) => const NearbyFacilityScreen(),
+        "/log": (context) => const WalkLogScreen(),
       },
     );
   }

--- a/lib/models/monthly_walk_log_model.dart
+++ b/lib/models/monthly_walk_log_model.dart
@@ -1,0 +1,30 @@
+class MonthlyWalkLogModel {
+  int logId;
+  String? walkingImageUrl;
+  double walkedDistance;
+  DateTime startedTime;
+  Duration walkingTime;
+
+  MonthlyWalkLogModel({
+    required this.logId,
+    required this.walkingImageUrl,
+    required this.walkedDistance,
+    required this.startedTime,
+    required this.walkingTime,
+  });
+
+  factory MonthlyWalkLogModel.fromJson(Map<String, dynamic> json) {
+    List<String> walkingTimeParts = json["walking_time"].split(":");
+    return MonthlyWalkLogModel(
+      logId: json["id"],
+      walkingImageUrl: json["walking_image_url"],
+      walkedDistance: json["walked_distance"],
+      startedTime: DateTime.parse(json["started_time"]),
+      walkingTime: Duration(
+        hours: int.parse(walkingTimeParts[0]),
+        minutes: int.parse(walkingTimeParts[1]),
+        seconds: int.parse(walkingTimeParts[2]),
+      ),
+    );
+  }
+}

--- a/lib/models/recently_walk_log_model.dart
+++ b/lib/models/recently_walk_log_model.dart
@@ -1,0 +1,16 @@
+class RecentlyWalkLogModel {
+  DateTime walkDate;
+  double totalWalkedDistance;
+
+  RecentlyWalkLogModel({
+    required this.walkDate,
+    required this.totalWalkedDistance,
+  });
+
+  factory RecentlyWalkLogModel.fromJson(Map<String, dynamic> json) {
+    return RecentlyWalkLogModel(
+      walkDate: DateTime.parse(json["walk_date"]),
+      totalWalkedDistance: json["total_walked_distance"],
+    );
+  }
+}

--- a/lib/screens/walk_log_screen.dart
+++ b/lib/screens/walk_log_screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:wooyoungsoo/models/monthly_walk_log_model.dart';
+import 'package:wooyoungsoo/services/walk_log_service/walk_log_service.dart';
 import 'package:wooyoungsoo/utils/constants.dart';
 import 'package:wooyoungsoo/widgets/common/navigation_bar_widget.dart';
 
@@ -14,9 +16,22 @@ class WalkLogScreen extends StatefulWidget {
 }
 
 class _WalkLogScreenState extends State<WalkLogScreen> {
+  final WalkLogService walkLogService = WalkLogService();
+  List<MonthlyWalkLogModel> monthlyWalkLogs = [];
+
+  void loadMonthlyWalkLogs() async {
+    monthlyWalkLogs = await walkLogService.getMonthlyWalkLogs(
+      year: DateTime.now().year,
+      month: DateTime.now().month,
+    );
+
+    setState(() {});
+  }
+
   @override
   void initState() {
     super.initState();
+    loadMonthlyWalkLogs();
   }
 
   @override
@@ -357,110 +372,153 @@ class _WalkLogScreenState extends State<WalkLogScreen> {
             const SizedBox(
               height: 20,
             ),
-            Container(
-              width: screenWidth * 0.934,
-              decoration: BoxDecoration(
-                color: whiteColor,
-                borderRadius: BorderRadius.circular(20),
-                boxShadow: const [
-                  BoxShadow(
-                    color: boxGreyColor,
-                    blurRadius: 50,
-                    offset: Offset(0, 0),
-                  ),
-                ],
+            Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: screenWidth * 0.033,
               ),
-              child: Padding(
-                padding: const EdgeInsets.all(10),
-                child: Row(
-                  children: [
-                    Container(
-                      width: 100,
-                      height: 100,
-                      decoration: BoxDecoration(
-                        color: darkGreyColor,
-                        borderRadius: BorderRadius.circular(20),
-                      ),
+              child: ListView.separated(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                itemBuilder: (context, index) {
+                  return Container(
+                    decoration: BoxDecoration(
+                      color: whiteColor,
+                      borderRadius: BorderRadius.circular(20),
+                      boxShadow: const [
+                        BoxShadow(
+                          color: boxGreyColor,
+                          blurRadius: 50,
+                          offset: Offset(0, 0),
+                        ),
+                      ],
                     ),
-                    const SizedBox(
-                      width: 20,
-                    ),
-                    const Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
+                    child: Padding(
+                      padding: const EdgeInsets.all(10),
+                      child: Row(
                         children: [
-                          Text(
-                            "2023. 11. 05",
-                            style: TextStyle(
-                              fontSize: 15,
-                              fontWeight: fontWeightBold,
-                              color: mainColor,
+                          monthlyWalkLogs[index].walkingImageUrl == null
+                              ? Container(
+                                  width: 100,
+                                  height: 100,
+                                  decoration: BoxDecoration(
+                                    borderRadius: BorderRadius.circular(20),
+                                    image: const DecorationImage(
+                                      image: AssetImage(
+                                          "assets/images/default_dog_image.png"),
+                                      fit: BoxFit.cover,
+                                    ),
+                                  ),
+                                )
+                              : Container(
+                                  width: 100,
+                                  height: 100,
+                                  decoration: BoxDecoration(
+                                    borderRadius: BorderRadius.circular(20),
+                                    image: DecorationImage(
+                                      image: NetworkImage(monthlyWalkLogs[index]
+                                          .walkingImageUrl!),
+                                      fit: BoxFit.cover,
+                                    ),
+                                  ),
+                                ),
+                          const SizedBox(
+                            width: 20,
+                          ),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  monthlyWalkLogs[index]
+                                      .startedTime
+                                      .toString()
+                                      .split(" ")[0],
+                                  style: const TextStyle(
+                                    fontSize: 15,
+                                    fontWeight: fontWeightBold,
+                                    color: mainColor,
+                                  ),
+                                ),
+                                const SizedBox(
+                                  height: 5,
+                                ),
+                                const Divider(
+                                  color: lightGreyColor,
+                                  thickness: 1,
+                                ),
+                                const SizedBox(
+                                  height: 5,
+                                ),
+                                const Row(
+                                  children: [
+                                    SizedBox(
+                                      width: 80,
+                                      child: Text(
+                                        "산책 시간",
+                                        style: TextStyle(
+                                          fontSize: 12,
+                                          fontWeight: fontWeightMedium,
+                                          color: darkGreyColor,
+                                        ),
+                                      ),
+                                    ),
+                                    Text(
+                                      "거리 (km)",
+                                      style: TextStyle(
+                                        fontSize: 12,
+                                        fontWeight: fontWeightMedium,
+                                        color: darkGreyColor,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                Row(
+                                  children: [
+                                    SizedBox(
+                                      width: 80,
+                                      child: Text(
+                                        monthlyWalkLogs[index]
+                                                    .walkingTime
+                                                    .toString()
+                                                    .split(".")[0][0] ==
+                                                "0"
+                                            ? "0${monthlyWalkLogs[index].walkingTime.toString().split(".")[0]}"
+                                            : monthlyWalkLogs[index]
+                                                .walkingTime
+                                                .toString()
+                                                .split(".")[0],
+                                        style: const TextStyle(
+                                          fontSize: 15,
+                                          fontWeight: fontWeightMedium,
+                                          color: blackColor,
+                                        ),
+                                      ),
+                                    ),
+                                    Text(
+                                      "${monthlyWalkLogs[index].walkedDistance}km",
+                                      style: const TextStyle(
+                                        fontSize: 15,
+                                        fontWeight: fontWeightMedium,
+                                        color: blackColor,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ],
                             ),
                           ),
-                          SizedBox(
-                            height: 5,
-                          ),
-                          Divider(
-                            color: lightGreyColor,
-                            thickness: 1,
-                          ),
-                          SizedBox(
-                            height: 5,
-                          ),
-                          Row(
-                            children: [
-                              SizedBox(
-                                width: 80,
-                                child: Text(
-                                  "산책 시간",
-                                  style: TextStyle(
-                                    fontSize: 12,
-                                    fontWeight: fontWeightMedium,
-                                    color: darkGreyColor,
-                                  ),
-                                ),
-                              ),
-                              Text(
-                                "거리 (km)",
-                                style: TextStyle(
-                                  fontSize: 12,
-                                  fontWeight: fontWeightMedium,
-                                  color: darkGreyColor,
-                                ),
-                              ),
-                            ],
-                          ),
-                          Row(
-                            children: [
-                              SizedBox(
-                                width: 80,
-                                child: Text(
-                                  "00:09:23",
-                                  style: TextStyle(
-                                    fontSize: 15,
-                                    fontWeight: fontWeightMedium,
-                                    color: blackColor,
-                                  ),
-                                ),
-                              ),
-                              Text(
-                                "1.2km",
-                                style: TextStyle(
-                                  fontSize: 15,
-                                  fontWeight: fontWeightMedium,
-                                  color: blackColor,
-                                ),
-                              ),
-                            ],
+                          const SizedBox(
+                            width: 10,
                           ),
                         ],
                       ),
                     ),
-                    const SizedBox(
-                      width: 10,
-                    ),
-                  ],
-                ),
+                  );
+                },
+                separatorBuilder: (context, index) {
+                  return const Gap();
+                },
+                itemCount: monthlyWalkLogs.length,
               ),
             ),
           ],
@@ -478,7 +536,7 @@ class Gap extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const SizedBox(
-      height: 30,
+      height: 10,
     );
   }
 }

--- a/lib/screens/walk_log_screen.dart
+++ b/lib/screens/walk_log_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:wooyoungsoo/models/monthly_walk_log_model.dart';
+import 'package:wooyoungsoo/models/recently_walk_log_model.dart';
 import 'package:wooyoungsoo/services/walk_log_service/walk_log_service.dart';
 import 'package:wooyoungsoo/utils/constants.dart';
 import 'package:wooyoungsoo/widgets/common/navigation_bar_widget.dart';
@@ -17,13 +19,22 @@ class WalkLogScreen extends StatefulWidget {
 
 class _WalkLogScreenState extends State<WalkLogScreen> {
   final WalkLogService walkLogService = WalkLogService();
+  List<RecentlyWalkLogModel> recentlyWalkLogs = [];
   List<MonthlyWalkLogModel> monthlyWalkLogs = [];
 
-  void loadMonthlyWalkLogs() async {
+  void loadWalkLogs() async {
+    recentlyWalkLogs = await walkLogService.getRecentlyWalkLogs();
+
     monthlyWalkLogs = await walkLogService.getMonthlyWalkLogs(
       year: DateTime.now().year,
       month: DateTime.now().month,
     );
+
+    for (var i = 0; i < recentlyWalkLogs.length; i++) {
+      print(recentlyWalkLogs[i].walkDate);
+      print(recentlyWalkLogs[i].totalWalkedDistance);
+      print("=============");
+    }
 
     setState(() {});
   }
@@ -31,7 +42,7 @@ class _WalkLogScreenState extends State<WalkLogScreen> {
   @override
   void initState() {
     super.initState();
-    loadMonthlyWalkLogs();
+    loadWalkLogs();
   }
 
   @override
@@ -114,211 +125,119 @@ class _WalkLogScreenState extends State<WalkLogScreen> {
                   width: 1,
                 ),
               ),
-              child: Column(
-                children: [
-                  SizedBox(
-                    width: 270,
-                    height: 30,
-                    child: ListView.separated(
-                      scrollDirection: Axis.horizontal,
-                      itemBuilder: (context, index) {
-                        return Container(
-                          width: 30,
-                          height: 30,
-                          decoration: BoxDecoration(
-                            color: mainColor,
-                            borderRadius: BorderRadius.circular(6),
-                          ),
-                        );
-                      },
-                      separatorBuilder: (context, index) {
-                        return const SizedBox(
-                          width: 10,
-                        );
-                      },
-                      itemCount: 7,
+              child: recentlyWalkLogs.isEmpty
+                  ? const SizedBox(
+                      height: 220,
+                      child: SpinKitCircle(
+                        color: mainColor,
+                        size: 50,
+                      ),
+                    )
+                  : Column(
+                      children: [
+                        WalkingFarmRow(
+                          walkLogs: recentlyWalkLogs.sublist(0, 7),
+                        ),
+                        const SizedBox(height: 8),
+                        WalkingFarmRow(
+                          walkLogs: recentlyWalkLogs.sublist(7, 14),
+                        ),
+                        const SizedBox(height: 8),
+                        WalkingFarmRow(
+                          walkLogs: recentlyWalkLogs.sublist(14, 21),
+                        ),
+                        const SizedBox(height: 8),
+                        WalkingFarmRow(
+                          walkLogs: recentlyWalkLogs.sublist(21, 28),
+                        ),
+                        const SizedBox(height: 8),
+                        WalkingFarmRow(
+                          walkLogs: recentlyWalkLogs.sublist(28, 30),
+                        ),
+                        const SizedBox(
+                          height: 20,
+                        ),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            const Text(
+                              "0km",
+                              style: TextStyle(
+                                fontSize: 12,
+                                fontWeight: fontWeightMedium,
+                                color: darkGreyColor,
+                              ),
+                            ),
+                            const SizedBox(
+                              width: 4,
+                            ),
+                            Container(
+                              width: 20,
+                              height: 20,
+                              decoration: BoxDecoration(
+                                color: blueColorLv1,
+                                borderRadius: BorderRadius.circular(6),
+                              ),
+                            ),
+                            const SizedBox(
+                              width: 4,
+                            ),
+                            Container(
+                              width: 20,
+                              height: 20,
+                              decoration: BoxDecoration(
+                                color: blueColorLv2,
+                                borderRadius: BorderRadius.circular(6),
+                              ),
+                            ),
+                            const SizedBox(
+                              width: 4,
+                            ),
+                            Container(
+                              width: 20,
+                              height: 20,
+                              decoration: BoxDecoration(
+                                color: blueColorLv3,
+                                borderRadius: BorderRadius.circular(6),
+                              ),
+                            ),
+                            const SizedBox(
+                              width: 4,
+                            ),
+                            Container(
+                              width: 20,
+                              height: 20,
+                              decoration: BoxDecoration(
+                                color: blueColorLv4,
+                                borderRadius: BorderRadius.circular(6),
+                              ),
+                            ),
+                            const SizedBox(
+                              width: 4,
+                            ),
+                            Container(
+                              width: 20,
+                              height: 20,
+                              decoration: BoxDecoration(
+                                color: blueColorLv5,
+                                borderRadius: BorderRadius.circular(6),
+                              ),
+                            ),
+                            const SizedBox(
+                              width: 4,
+                            ),
+                            const Text(
+                              "3km",
+                              style: TextStyle(
+                                fontSize: 12,
+                                fontWeight: fontWeightMedium,
+                                color: darkGreyColor,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
                     ),
-                  ),
-                  const SizedBox(height: 8),
-                  SizedBox(
-                    width: 270,
-                    height: 30,
-                    child: ListView.separated(
-                      scrollDirection: Axis.horizontal,
-                      itemBuilder: (context, index) {
-                        return Container(
-                          width: 30,
-                          height: 30,
-                          decoration: BoxDecoration(
-                            color: mainColor,
-                            borderRadius: BorderRadius.circular(6),
-                          ),
-                        );
-                      },
-                      separatorBuilder: (context, index) {
-                        return const SizedBox(
-                          width: 10,
-                        );
-                      },
-                      itemCount: 7,
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  SizedBox(
-                    width: 270,
-                    height: 30,
-                    child: ListView.separated(
-                      scrollDirection: Axis.horizontal,
-                      itemBuilder: (context, index) {
-                        return Container(
-                          width: 30,
-                          height: 30,
-                          decoration: BoxDecoration(
-                            color: mainColor,
-                            borderRadius: BorderRadius.circular(6),
-                          ),
-                        );
-                      },
-                      separatorBuilder: (context, index) {
-                        return const SizedBox(
-                          width: 10,
-                        );
-                      },
-                      itemCount: 7,
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  SizedBox(
-                    width: 270,
-                    height: 30,
-                    child: ListView.separated(
-                      scrollDirection: Axis.horizontal,
-                      itemBuilder: (context, index) {
-                        return Container(
-                          width: 30,
-                          height: 30,
-                          decoration: BoxDecoration(
-                            color: mainColor,
-                            borderRadius: BorderRadius.circular(6),
-                          ),
-                        );
-                      },
-                      separatorBuilder: (context, index) {
-                        return const SizedBox(
-                          width: 10,
-                        );
-                      },
-                      itemCount: 7,
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  SizedBox(
-                    width: 270,
-                    height: 30,
-                    child: ListView.separated(
-                      scrollDirection: Axis.horizontal,
-                      itemBuilder: (context, index) {
-                        return Container(
-                          width: 30,
-                          height: 30,
-                          decoration: BoxDecoration(
-                            color: mainColor,
-                            borderRadius: BorderRadius.circular(6),
-                          ),
-                        );
-                      },
-                      separatorBuilder: (context, index) {
-                        return const SizedBox(
-                          width: 10,
-                        );
-                      },
-                      itemCount: 2,
-                    ),
-                  ),
-                  const SizedBox(
-                    height: 20,
-                  ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      const Text(
-                        "0km",
-                        style: TextStyle(
-                          fontSize: 12,
-                          fontWeight: fontWeightMedium,
-                          color: darkGreyColor,
-                        ),
-                      ),
-                      const SizedBox(
-                        width: 4,
-                      ),
-                      Container(
-                        width: 20,
-                        height: 20,
-                        decoration: BoxDecoration(
-                          color: blueColorLv1,
-                          borderRadius: BorderRadius.circular(6),
-                        ),
-                      ),
-                      const SizedBox(
-                        width: 4,
-                      ),
-                      Container(
-                        width: 20,
-                        height: 20,
-                        decoration: BoxDecoration(
-                          color: blueColorLv2,
-                          borderRadius: BorderRadius.circular(6),
-                        ),
-                      ),
-                      const SizedBox(
-                        width: 4,
-                      ),
-                      Container(
-                        width: 20,
-                        height: 20,
-                        decoration: BoxDecoration(
-                          color: blueColorLv3,
-                          borderRadius: BorderRadius.circular(6),
-                        ),
-                      ),
-                      const SizedBox(
-                        width: 4,
-                      ),
-                      Container(
-                        width: 20,
-                        height: 20,
-                        decoration: BoxDecoration(
-                          color: blueColorLv4,
-                          borderRadius: BorderRadius.circular(6),
-                        ),
-                      ),
-                      const SizedBox(
-                        width: 4,
-                      ),
-                      Container(
-                        width: 20,
-                        height: 20,
-                        decoration: BoxDecoration(
-                          color: blueColorLv5,
-                          borderRadius: BorderRadius.circular(6),
-                        ),
-                      ),
-                      const SizedBox(
-                        width: 4,
-                      ),
-                      const Text(
-                        "5km",
-                        style: TextStyle(
-                          fontSize: 12,
-                          fontWeight: fontWeightMedium,
-                          color: darkGreyColor,
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
             ),
             Padding(
               padding: EdgeInsets.symmetric(
@@ -523,6 +442,79 @@ class _WalkLogScreenState extends State<WalkLogScreen> {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class WalkingFarmRow extends StatelessWidget {
+  const WalkingFarmRow({
+    super.key,
+    required this.walkLogs,
+  });
+
+  final List<RecentlyWalkLogModel> walkLogs;
+
+  Color getWalkLogColor(double walkedDistance) {
+    if (walkedDistance == 0) {
+      return blueColorLv1;
+    }
+    if (walkedDistance < 1) {
+      return blueColorLv2;
+    }
+    if (walkedDistance < 2) {
+      return blueColorLv3;
+    }
+    if (walkedDistance < 3) {
+      return blueColorLv4;
+    }
+    return blueColorLv5;
+  }
+
+  Color getDayColor(double walkedDistance) {
+    if (walkedDistance < 2) {
+      return darkGreyColor;
+    }
+    return whiteColor;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 270,
+      height: 30,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        itemBuilder: (context, index) {
+          return Container(
+            width: 30,
+            height: 30,
+            decoration: BoxDecoration(
+              color: getWalkLogColor(walkLogs[index].totalWalkedDistance),
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  walkLogs[index].walkDate.day.toString(),
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: fontWeightBold,
+                    color: getDayColor(walkLogs[index].totalWalkedDistance),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+        separatorBuilder: (context, index) {
+          return const SizedBox(
+            width: 10,
+          );
+        },
+        itemCount: walkLogs.length,
       ),
     );
   }

--- a/lib/screens/walk_log_screen.dart
+++ b/lib/screens/walk_log_screen.dart
@@ -1,0 +1,484 @@
+import 'package:flutter/material.dart';
+import 'package:wooyoungsoo/utils/constants.dart';
+import 'package:wooyoungsoo/widgets/common/navigation_bar_widget.dart';
+
+/// 마이페이지 화면
+///
+/// [screenWidth], [screenHeight] 화면의 너비와 높이
+/// [currentIndex] 현재 화면의 인덱스
+class WalkLogScreen extends StatefulWidget {
+  const WalkLogScreen({Key? key}) : super(key: key);
+
+  @override
+  State<WalkLogScreen> createState() => _WalkLogScreenState();
+}
+
+class _WalkLogScreenState extends State<WalkLogScreen> {
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final double screenWidth = MediaQuery.of(context).size.width;
+    final double screenHeight = MediaQuery.of(context).size.height;
+    const int currentIndex = 1;
+
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: whiteColor,
+        shadowColor: transparentColor,
+        leadingWidth: 115,
+        leading: Padding(
+          padding: EdgeInsets.only(
+            top: 15,
+            left: screenWidth * 0.033,
+          ),
+          child: const Text(
+            "산책 기록",
+            style: TextStyle(
+              fontSize: 18,
+              fontWeight: fontWeightBold,
+              color: blackColor,
+            ),
+          ),
+        ),
+      ),
+      backgroundColor: whiteColor,
+      bottomNavigationBar:
+          const PetdoriNavigationBar(currentIndex: currentIndex),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            const SizedBox(
+              height: 15,
+            ),
+            Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: screenWidth * 0.033,
+              ),
+              child: const Row(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Text(
+                    "산책 밭",
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: fontWeightBold,
+                      color: blackColor,
+                    ),
+                  ),
+                  SizedBox(
+                    width: 10,
+                  ),
+                  Text(
+                    "최근 30일",
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: fontWeightMedium,
+                      color: mainColor,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Container(
+              width: screenWidth * 0.934,
+              margin: EdgeInsets.only(
+                top: screenHeight * 0.02,
+                bottom: screenHeight * 0.04,
+              ),
+              padding: const EdgeInsets.symmetric(
+                vertical: 20,
+              ),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(20),
+                border: Border.all(
+                  color: lightGreyColor,
+                  width: 1,
+                ),
+              ),
+              child: Column(
+                children: [
+                  SizedBox(
+                    width: 270,
+                    height: 30,
+                    child: ListView.separated(
+                      scrollDirection: Axis.horizontal,
+                      itemBuilder: (context, index) {
+                        return Container(
+                          width: 30,
+                          height: 30,
+                          decoration: BoxDecoration(
+                            color: mainColor,
+                            borderRadius: BorderRadius.circular(6),
+                          ),
+                        );
+                      },
+                      separatorBuilder: (context, index) {
+                        return const SizedBox(
+                          width: 10,
+                        );
+                      },
+                      itemCount: 7,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  SizedBox(
+                    width: 270,
+                    height: 30,
+                    child: ListView.separated(
+                      scrollDirection: Axis.horizontal,
+                      itemBuilder: (context, index) {
+                        return Container(
+                          width: 30,
+                          height: 30,
+                          decoration: BoxDecoration(
+                            color: mainColor,
+                            borderRadius: BorderRadius.circular(6),
+                          ),
+                        );
+                      },
+                      separatorBuilder: (context, index) {
+                        return const SizedBox(
+                          width: 10,
+                        );
+                      },
+                      itemCount: 7,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  SizedBox(
+                    width: 270,
+                    height: 30,
+                    child: ListView.separated(
+                      scrollDirection: Axis.horizontal,
+                      itemBuilder: (context, index) {
+                        return Container(
+                          width: 30,
+                          height: 30,
+                          decoration: BoxDecoration(
+                            color: mainColor,
+                            borderRadius: BorderRadius.circular(6),
+                          ),
+                        );
+                      },
+                      separatorBuilder: (context, index) {
+                        return const SizedBox(
+                          width: 10,
+                        );
+                      },
+                      itemCount: 7,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  SizedBox(
+                    width: 270,
+                    height: 30,
+                    child: ListView.separated(
+                      scrollDirection: Axis.horizontal,
+                      itemBuilder: (context, index) {
+                        return Container(
+                          width: 30,
+                          height: 30,
+                          decoration: BoxDecoration(
+                            color: mainColor,
+                            borderRadius: BorderRadius.circular(6),
+                          ),
+                        );
+                      },
+                      separatorBuilder: (context, index) {
+                        return const SizedBox(
+                          width: 10,
+                        );
+                      },
+                      itemCount: 7,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  SizedBox(
+                    width: 270,
+                    height: 30,
+                    child: ListView.separated(
+                      scrollDirection: Axis.horizontal,
+                      itemBuilder: (context, index) {
+                        return Container(
+                          width: 30,
+                          height: 30,
+                          decoration: BoxDecoration(
+                            color: mainColor,
+                            borderRadius: BorderRadius.circular(6),
+                          ),
+                        );
+                      },
+                      separatorBuilder: (context, index) {
+                        return const SizedBox(
+                          width: 10,
+                        );
+                      },
+                      itemCount: 2,
+                    ),
+                  ),
+                  const SizedBox(
+                    height: 20,
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Text(
+                        "0km",
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: fontWeightMedium,
+                          color: darkGreyColor,
+                        ),
+                      ),
+                      const SizedBox(
+                        width: 4,
+                      ),
+                      Container(
+                        width: 20,
+                        height: 20,
+                        decoration: BoxDecoration(
+                          color: blueColorLv1,
+                          borderRadius: BorderRadius.circular(6),
+                        ),
+                      ),
+                      const SizedBox(
+                        width: 4,
+                      ),
+                      Container(
+                        width: 20,
+                        height: 20,
+                        decoration: BoxDecoration(
+                          color: blueColorLv2,
+                          borderRadius: BorderRadius.circular(6),
+                        ),
+                      ),
+                      const SizedBox(
+                        width: 4,
+                      ),
+                      Container(
+                        width: 20,
+                        height: 20,
+                        decoration: BoxDecoration(
+                          color: blueColorLv3,
+                          borderRadius: BorderRadius.circular(6),
+                        ),
+                      ),
+                      const SizedBox(
+                        width: 4,
+                      ),
+                      Container(
+                        width: 20,
+                        height: 20,
+                        decoration: BoxDecoration(
+                          color: blueColorLv4,
+                          borderRadius: BorderRadius.circular(6),
+                        ),
+                      ),
+                      const SizedBox(
+                        width: 4,
+                      ),
+                      Container(
+                        width: 20,
+                        height: 20,
+                        decoration: BoxDecoration(
+                          color: blueColorLv5,
+                          borderRadius: BorderRadius.circular(6),
+                        ),
+                      ),
+                      const SizedBox(
+                        width: 4,
+                      ),
+                      const Text(
+                        "5km",
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: fontWeightMedium,
+                          color: darkGreyColor,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: screenWidth * 0.033,
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text(
+                    "이번 달 산책 기록",
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: fontWeightBold,
+                      color: blackColor,
+                    ),
+                  ),
+                  TextButton(
+                    style: TextButton.styleFrom(
+                      minimumSize: Size.zero,
+                      padding: EdgeInsets.zero,
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      shadowColor: Colors.transparent,
+                    ),
+                    onPressed: () {},
+                    child: const Row(
+                      children: [
+                        Baseline(
+                          baselineType: TextBaseline.alphabetic,
+                          baseline: 15,
+                          child: Text(
+                            "다른 달 기록 보기",
+                            style: TextStyle(
+                              color: darkGreyColor,
+                              fontSize: 14,
+                              fontWeight: fontWeightMedium,
+                            ),
+                          ),
+                        ),
+                        Icon(
+                          Icons.arrow_forward_ios_outlined,
+                          color: darkGreyColor,
+                          size: 12,
+                        ),
+                      ],
+                    ),
+                  )
+                ],
+              ),
+            ),
+            const SizedBox(
+              height: 20,
+            ),
+            Container(
+              width: screenWidth * 0.934,
+              decoration: BoxDecoration(
+                color: whiteColor,
+                borderRadius: BorderRadius.circular(20),
+                boxShadow: const [
+                  BoxShadow(
+                    color: boxGreyColor,
+                    blurRadius: 50,
+                    offset: Offset(0, 0),
+                  ),
+                ],
+              ),
+              child: Padding(
+                padding: const EdgeInsets.all(10),
+                child: Row(
+                  children: [
+                    Container(
+                      width: 100,
+                      height: 100,
+                      decoration: BoxDecoration(
+                        color: darkGreyColor,
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                    ),
+                    const SizedBox(
+                      width: 20,
+                    ),
+                    const Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            "2023. 11. 05",
+                            style: TextStyle(
+                              fontSize: 15,
+                              fontWeight: fontWeightBold,
+                              color: mainColor,
+                            ),
+                          ),
+                          SizedBox(
+                            height: 5,
+                          ),
+                          Divider(
+                            color: lightGreyColor,
+                            thickness: 1,
+                          ),
+                          SizedBox(
+                            height: 5,
+                          ),
+                          Row(
+                            children: [
+                              SizedBox(
+                                width: 80,
+                                child: Text(
+                                  "산책 시간",
+                                  style: TextStyle(
+                                    fontSize: 12,
+                                    fontWeight: fontWeightMedium,
+                                    color: darkGreyColor,
+                                  ),
+                                ),
+                              ),
+                              Text(
+                                "거리 (km)",
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  fontWeight: fontWeightMedium,
+                                  color: darkGreyColor,
+                                ),
+                              ),
+                            ],
+                          ),
+                          Row(
+                            children: [
+                              SizedBox(
+                                width: 80,
+                                child: Text(
+                                  "00:09:23",
+                                  style: TextStyle(
+                                    fontSize: 15,
+                                    fontWeight: fontWeightMedium,
+                                    color: blackColor,
+                                  ),
+                                ),
+                              ),
+                              Text(
+                                "1.2km",
+                                style: TextStyle(
+                                  fontSize: 15,
+                                  fontWeight: fontWeightMedium,
+                                  color: blackColor,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(
+                      width: 10,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class Gap extends StatelessWidget {
+  const Gap({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(
+      height: 30,
+    );
+  }
+}

--- a/lib/screens/walk_log_screen.dart
+++ b/lib/screens/walk_log_screen.dart
@@ -5,8 +5,11 @@ import 'package:wooyoungsoo/models/recently_walk_log_model.dart';
 import 'package:wooyoungsoo/services/walk_log_service/walk_log_service.dart';
 import 'package:wooyoungsoo/utils/constants.dart';
 import 'package:wooyoungsoo/widgets/common/navigation_bar_widget.dart';
+import 'package:wooyoungsoo/widgets/walk_log_screen/monthly_walking_log_view_widget.dart';
+import 'package:wooyoungsoo/widgets/walk_log_screen/walking_farm_color_bar_widget.dart';
+import 'package:wooyoungsoo/widgets/walk_log_screen/walking_farm_row_widget.dart';
 
-/// 마이페이지 화면
+/// 산책 로그 화면
 ///
 /// [screenWidth], [screenHeight] 화면의 너비와 높이
 /// [currentIndex] 현재 화면의 인덱스
@@ -17,6 +20,11 @@ class WalkLogScreen extends StatefulWidget {
   State<WalkLogScreen> createState() => _WalkLogScreenState();
 }
 
+/// 산책 로그 화면의 상태
+///
+/// [walkLogService] 산책 로그 서비스
+/// [recentlyWalkLogs] 최근 30일 산책 로그 리스트
+/// [monthlyWalkLogs] 이번 달 산책 로그 리스트
 class _WalkLogScreenState extends State<WalkLogScreen> {
   final WalkLogService walkLogService = WalkLogService();
   List<RecentlyWalkLogModel> recentlyWalkLogs = [];
@@ -29,12 +37,6 @@ class _WalkLogScreenState extends State<WalkLogScreen> {
       year: DateTime.now().year,
       month: DateTime.now().month,
     );
-
-    for (var i = 0; i < recentlyWalkLogs.length; i++) {
-      print(recentlyWalkLogs[i].walkDate);
-      print(recentlyWalkLogs[i].totalWalkedDistance);
-      print("=============");
-    }
 
     setState(() {});
   }
@@ -157,85 +159,7 @@ class _WalkLogScreenState extends State<WalkLogScreen> {
                         const SizedBox(
                           height: 20,
                         ),
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            const Text(
-                              "0km",
-                              style: TextStyle(
-                                fontSize: 12,
-                                fontWeight: fontWeightMedium,
-                                color: darkGreyColor,
-                              ),
-                            ),
-                            const SizedBox(
-                              width: 4,
-                            ),
-                            Container(
-                              width: 20,
-                              height: 20,
-                              decoration: BoxDecoration(
-                                color: blueColorLv1,
-                                borderRadius: BorderRadius.circular(6),
-                              ),
-                            ),
-                            const SizedBox(
-                              width: 4,
-                            ),
-                            Container(
-                              width: 20,
-                              height: 20,
-                              decoration: BoxDecoration(
-                                color: blueColorLv2,
-                                borderRadius: BorderRadius.circular(6),
-                              ),
-                            ),
-                            const SizedBox(
-                              width: 4,
-                            ),
-                            Container(
-                              width: 20,
-                              height: 20,
-                              decoration: BoxDecoration(
-                                color: blueColorLv3,
-                                borderRadius: BorderRadius.circular(6),
-                              ),
-                            ),
-                            const SizedBox(
-                              width: 4,
-                            ),
-                            Container(
-                              width: 20,
-                              height: 20,
-                              decoration: BoxDecoration(
-                                color: blueColorLv4,
-                                borderRadius: BorderRadius.circular(6),
-                              ),
-                            ),
-                            const SizedBox(
-                              width: 4,
-                            ),
-                            Container(
-                              width: 20,
-                              height: 20,
-                              decoration: BoxDecoration(
-                                color: blueColorLv5,
-                                borderRadius: BorderRadius.circular(6),
-                              ),
-                            ),
-                            const SizedBox(
-                              width: 4,
-                            ),
-                            const Text(
-                              "3km",
-                              style: TextStyle(
-                                fontSize: 12,
-                                fontWeight: fontWeightMedium,
-                                color: darkGreyColor,
-                              ),
-                            ),
-                          ],
-                        ),
+                        const WalkingFarmColorBar(),
                       ],
                     ),
             ),
@@ -291,244 +215,13 @@ class _WalkLogScreenState extends State<WalkLogScreen> {
             const SizedBox(
               height: 20,
             ),
-            Padding(
-              padding: EdgeInsets.symmetric(
-                horizontal: screenWidth * 0.033,
-              ),
-              child: ListView.separated(
-                shrinkWrap: true,
-                physics: const NeverScrollableScrollPhysics(),
-                itemBuilder: (context, index) {
-                  return Container(
-                    decoration: BoxDecoration(
-                      color: whiteColor,
-                      borderRadius: BorderRadius.circular(20),
-                      boxShadow: const [
-                        BoxShadow(
-                          color: boxGreyColor,
-                          blurRadius: 50,
-                          offset: Offset(0, 0),
-                        ),
-                      ],
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.all(10),
-                      child: Row(
-                        children: [
-                          monthlyWalkLogs[index].walkingImageUrl == null
-                              ? Container(
-                                  width: 100,
-                                  height: 100,
-                                  decoration: BoxDecoration(
-                                    borderRadius: BorderRadius.circular(20),
-                                    image: const DecorationImage(
-                                      image: AssetImage(
-                                          "assets/images/default_dog_image.png"),
-                                      fit: BoxFit.cover,
-                                    ),
-                                  ),
-                                )
-                              : Container(
-                                  width: 100,
-                                  height: 100,
-                                  decoration: BoxDecoration(
-                                    borderRadius: BorderRadius.circular(20),
-                                    image: DecorationImage(
-                                      image: NetworkImage(monthlyWalkLogs[index]
-                                          .walkingImageUrl!),
-                                      fit: BoxFit.cover,
-                                    ),
-                                  ),
-                                ),
-                          const SizedBox(
-                            width: 20,
-                          ),
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  monthlyWalkLogs[index]
-                                      .startedTime
-                                      .toString()
-                                      .split(" ")[0],
-                                  style: const TextStyle(
-                                    fontSize: 15,
-                                    fontWeight: fontWeightBold,
-                                    color: mainColor,
-                                  ),
-                                ),
-                                const SizedBox(
-                                  height: 5,
-                                ),
-                                const Divider(
-                                  color: lightGreyColor,
-                                  thickness: 1,
-                                ),
-                                const SizedBox(
-                                  height: 5,
-                                ),
-                                const Row(
-                                  children: [
-                                    SizedBox(
-                                      width: 80,
-                                      child: Text(
-                                        "산책 시간",
-                                        style: TextStyle(
-                                          fontSize: 12,
-                                          fontWeight: fontWeightMedium,
-                                          color: darkGreyColor,
-                                        ),
-                                      ),
-                                    ),
-                                    Text(
-                                      "거리 (km)",
-                                      style: TextStyle(
-                                        fontSize: 12,
-                                        fontWeight: fontWeightMedium,
-                                        color: darkGreyColor,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                                Row(
-                                  children: [
-                                    SizedBox(
-                                      width: 80,
-                                      child: Text(
-                                        monthlyWalkLogs[index]
-                                                    .walkingTime
-                                                    .toString()
-                                                    .split(".")[0][0] ==
-                                                "0"
-                                            ? "0${monthlyWalkLogs[index].walkingTime.toString().split(".")[0]}"
-                                            : monthlyWalkLogs[index]
-                                                .walkingTime
-                                                .toString()
-                                                .split(".")[0],
-                                        style: const TextStyle(
-                                          fontSize: 15,
-                                          fontWeight: fontWeightMedium,
-                                          color: blackColor,
-                                        ),
-                                      ),
-                                    ),
-                                    Text(
-                                      "${monthlyWalkLogs[index].walkedDistance}km",
-                                      style: const TextStyle(
-                                        fontSize: 15,
-                                        fontWeight: fontWeightMedium,
-                                        color: blackColor,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ],
-                            ),
-                          ),
-                          const SizedBox(
-                            width: 10,
-                          ),
-                        ],
-                      ),
-                    ),
-                  );
-                },
-                separatorBuilder: (context, index) {
-                  return const Gap();
-                },
-                itemCount: monthlyWalkLogs.length,
-              ),
+            MonthlyWalkingLogView(
+              screenWidth: screenWidth,
+              monthlyWalkLogs: monthlyWalkLogs,
             ),
           ],
         ),
       ),
-    );
-  }
-}
-
-class WalkingFarmRow extends StatelessWidget {
-  const WalkingFarmRow({
-    super.key,
-    required this.walkLogs,
-  });
-
-  final List<RecentlyWalkLogModel> walkLogs;
-
-  Color getWalkLogColor(double walkedDistance) {
-    if (walkedDistance == 0) {
-      return blueColorLv1;
-    }
-    if (walkedDistance < 1) {
-      return blueColorLv2;
-    }
-    if (walkedDistance < 2) {
-      return blueColorLv3;
-    }
-    if (walkedDistance < 3) {
-      return blueColorLv4;
-    }
-    return blueColorLv5;
-  }
-
-  Color getDayColor(double walkedDistance) {
-    if (walkedDistance < 2) {
-      return darkGreyColor;
-    }
-    return whiteColor;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: 270,
-      height: 30,
-      child: ListView.separated(
-        scrollDirection: Axis.horizontal,
-        itemBuilder: (context, index) {
-          return Container(
-            width: 30,
-            height: 30,
-            decoration: BoxDecoration(
-              color: getWalkLogColor(walkLogs[index].totalWalkedDistance),
-              borderRadius: BorderRadius.circular(6),
-            ),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Text(
-                  walkLogs[index].walkDate.day.toString(),
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    fontSize: 13,
-                    fontWeight: fontWeightBold,
-                    color: getDayColor(walkLogs[index].totalWalkedDistance),
-                  ),
-                ),
-              ],
-            ),
-          );
-        },
-        separatorBuilder: (context, index) {
-          return const SizedBox(
-            width: 10,
-          );
-        },
-        itemCount: walkLogs.length,
-      ),
-    );
-  }
-}
-
-class Gap extends StatelessWidget {
-  const Gap({
-    super.key,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return const SizedBox(
-      height: 10,
     );
   }
 }

--- a/lib/services/auth_service/auth_service.dart
+++ b/lib/services/auth_service/auth_service.dart
@@ -191,6 +191,7 @@ class AuthService {
       var reissueResponse = BaseResponseModel.fromJson(res.data);
       if (reissueResponse.status == "success") {
         var accessToken = reissueResponse.data["access_token"];
+        debugPrint("accessToken: $accessToken");
         var refreshToken = reissueResponse.data["refresh_token"];
         goToHomeScreen(context, accessToken, refreshToken);
         return;

--- a/lib/services/walk_log_service/walk_log_service.dart
+++ b/lib/services/walk_log_service/walk_log_service.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:wooyoungsoo/models/base_response_model.dart';
 import 'package:wooyoungsoo/models/monthly_walk_log_model.dart';
+import 'package:wooyoungsoo/models/recently_walk_log_model.dart';
 import 'package:wooyoungsoo/services/storage_service/storage_service.dart';
 import 'package:wooyoungsoo/utils/constants.dart';
 
@@ -15,6 +16,31 @@ class WalkLogService {
 
   factory WalkLogService() {
     return _instance;
+  }
+
+  Future<List<RecentlyWalkLogModel>> getRecentlyWalkLogs() async {
+    try {
+      var accessToken = await storageService.getValue(key: "accessToken");
+
+      var res = await dio.get(
+        "$baseURL/api/walk-log/recently-logs",
+        options: Options(
+          headers: {
+            "Authorization": "Bearer $accessToken",
+          },
+        ),
+      );
+
+      var recentlyWalkLogsResponse = BaseResponseModel.fromJson(res.data);
+
+      return List<RecentlyWalkLogModel>.from(
+        recentlyWalkLogsResponse.data.map(
+          (walkLog) => RecentlyWalkLogModel.fromJson(walkLog),
+        ),
+      );
+    } on DioException {
+      return [];
+    }
   }
 
   Future<List<MonthlyWalkLogModel>> getMonthlyWalkLogs({

--- a/lib/services/walk_log_service/walk_log_service.dart
+++ b/lib/services/walk_log_service/walk_log_service.dart
@@ -1,0 +1,47 @@
+import 'package:dio/dio.dart';
+import 'package:wooyoungsoo/models/base_response_model.dart';
+import 'package:wooyoungsoo/models/monthly_walk_log_model.dart';
+import 'package:wooyoungsoo/services/storage_service/storage_service.dart';
+import 'package:wooyoungsoo/utils/constants.dart';
+
+/// 산책 기록을 위한 서비스(싱글턴)
+class WalkLogService {
+  final Dio dio = Dio();
+  final storageService = StorageService();
+
+  // private한 생성자 생성 => public 생성자가 없어짐
+  WalkLogService._privateConstructor();
+  static final WalkLogService _instance = WalkLogService._privateConstructor();
+
+  factory WalkLogService() {
+    return _instance;
+  }
+
+  Future<List<MonthlyWalkLogModel>> getMonthlyWalkLogs({
+    required int year,
+    required int month,
+  }) async {
+    try {
+      var accessToken = await storageService.getValue(key: "accessToken");
+
+      var res = await dio.get(
+        "$baseURL/api/walk-log/monthly-logs?year=$year&month=$month",
+        options: Options(
+          headers: {
+            "Authorization": "Bearer $accessToken",
+          },
+        ),
+      );
+
+      var monthlyWalkLogsResponse = BaseResponseModel.fromJson(res.data);
+
+      return List<MonthlyWalkLogModel>.from(
+        monthlyWalkLogsResponse.data.map(
+          (walkLog) => MonthlyWalkLogModel.fromJson(walkLog),
+        ),
+      );
+    } on DioException {
+      return [];
+    }
+  }
+}

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -28,6 +28,7 @@ const mainColor = Color(0xFF3c99f8);
 const lightBlueColor = Color(0xFFe1f0ff);
 const thinGreyColor = Color(0xFFf8f8f8);
 const lightGreyColor = Color(0xFFefefef);
+const boxGreyColor = Color.fromARGB(255, 223, 222, 222);
 const mediumGreyColor = Color(0xFFa0a0a0);
 const darkGreyColor = Color(0xFF8c8c8c);
 const navGreyColor = Color.fromARGB(255, 201, 201, 201);
@@ -36,6 +37,13 @@ const transparentColor = Colors.transparent;
 const blackColor = Color(0xFF292929);
 const whiteColor = Color(0xFFffffff);
 const redColor = Color(0xFFe74133);
+
+// 산책 밭 컬러
+const blueColorLv1 = Color(0xFFefefef);
+const blueColorLv2 = Color(0xFFEEF6FE);
+const blueColorLv3 = Color(0xFFC9E3FF);
+const blueColorLv4 = Color(0xFF89C2FD);
+const blueColorLv5 = Color(0xFF3c99f8);
 
 // 폰트 굵기 관련 상수들
 const fontWeightThin = FontWeight.w100;

--- a/lib/widgets/walk_log_screen/monthly_walking_log_view_widget.dart
+++ b/lib/widgets/walk_log_screen/monthly_walking_log_view_widget.dart
@@ -1,0 +1,184 @@
+import 'package:flutter/material.dart';
+import 'package:wooyoungsoo/models/monthly_walk_log_model.dart';
+import 'package:wooyoungsoo/utils/constants.dart';
+
+/// 월별 산책 기록 리스트 위젯
+///
+/// [screenWidth] 화면의 너비
+/// [monthlyWalkLogs] 월별 산책 기록 목록
+class MonthlyWalkingLogView extends StatelessWidget {
+  const MonthlyWalkingLogView({
+    super.key,
+    required this.screenWidth,
+    required this.monthlyWalkLogs,
+  });
+
+  final double screenWidth;
+  final List<MonthlyWalkLogModel> monthlyWalkLogs;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: screenWidth * 0.033,
+      ),
+      child: ListView.separated(
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
+        itemBuilder: (context, index) {
+          return Container(
+            decoration: BoxDecoration(
+              color: whiteColor,
+              borderRadius: BorderRadius.circular(20),
+              boxShadow: const [
+                BoxShadow(
+                  color: boxGreyColor,
+                  blurRadius: 50,
+                  offset: Offset(0, 0),
+                ),
+              ],
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(10),
+              child: Row(
+                children: [
+                  monthlyWalkLogs[index].walkingImageUrl == null
+                      ? Container(
+                          width: 100,
+                          height: 100,
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(20),
+                            image: const DecorationImage(
+                              image: AssetImage(
+                                  "assets/images/default_dog_image.png"),
+                              fit: BoxFit.cover,
+                            ),
+                          ),
+                        )
+                      : Container(
+                          width: 100,
+                          height: 100,
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(20),
+                            image: DecorationImage(
+                              image: NetworkImage(
+                                  monthlyWalkLogs[index].walkingImageUrl!),
+                              fit: BoxFit.cover,
+                            ),
+                          ),
+                        ),
+                  const SizedBox(
+                    width: 20,
+                  ),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          monthlyWalkLogs[index]
+                              .startedTime
+                              .toString()
+                              .split(" ")[0],
+                          style: const TextStyle(
+                            fontSize: 15,
+                            fontWeight: fontWeightBold,
+                            color: mainColor,
+                          ),
+                        ),
+                        const SizedBox(
+                          height: 5,
+                        ),
+                        const Divider(
+                          color: lightGreyColor,
+                          thickness: 1,
+                        ),
+                        const SizedBox(
+                          height: 5,
+                        ),
+                        const Row(
+                          children: [
+                            SizedBox(
+                              width: 80,
+                              child: Text(
+                                "산책 시간",
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  fontWeight: fontWeightMedium,
+                                  color: darkGreyColor,
+                                ),
+                              ),
+                            ),
+                            Text(
+                              "거리 (km)",
+                              style: TextStyle(
+                                fontSize: 12,
+                                fontWeight: fontWeightMedium,
+                                color: darkGreyColor,
+                              ),
+                            ),
+                          ],
+                        ),
+                        Row(
+                          children: [
+                            SizedBox(
+                              width: 80,
+                              child: Text(
+                                monthlyWalkLogs[index]
+                                            .walkingTime
+                                            .toString()
+                                            .split(".")[0][0] ==
+                                        "0"
+                                    ? "0${monthlyWalkLogs[index].walkingTime.toString().split(".")[0]}"
+                                    : monthlyWalkLogs[index]
+                                        .walkingTime
+                                        .toString()
+                                        .split(".")[0],
+                                style: const TextStyle(
+                                  fontSize: 15,
+                                  fontWeight: fontWeightMedium,
+                                  color: blackColor,
+                                ),
+                              ),
+                            ),
+                            Text(
+                              "${monthlyWalkLogs[index].walkedDistance}km",
+                              style: const TextStyle(
+                                fontSize: 15,
+                                fontWeight: fontWeightMedium,
+                                color: blackColor,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(
+                    width: 10,
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+        separatorBuilder: (context, index) {
+          return const Gap();
+        },
+        itemCount: monthlyWalkLogs.length,
+      ),
+    );
+  }
+}
+
+class Gap extends StatelessWidget {
+  const Gap({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(
+      height: 10,
+    );
+  }
+}

--- a/lib/widgets/walk_log_screen/walking_farm_color_bar_widget.dart
+++ b/lib/widgets/walk_log_screen/walking_farm_color_bar_widget.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:wooyoungsoo/utils/constants.dart';
+
+/// 최근 산책 기록 밭 색상 바 위젯
+class WalkingFarmColorBar extends StatelessWidget {
+  const WalkingFarmColorBar({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const Text(
+          "0km",
+          style: TextStyle(
+            fontSize: 12,
+            fontWeight: fontWeightMedium,
+            color: darkGreyColor,
+          ),
+        ),
+        const SizedBox(
+          width: 4,
+        ),
+        Container(
+          width: 20,
+          height: 20,
+          decoration: BoxDecoration(
+            color: blueColorLv1,
+            borderRadius: BorderRadius.circular(6),
+          ),
+        ),
+        const SizedBox(
+          width: 4,
+        ),
+        Container(
+          width: 20,
+          height: 20,
+          decoration: BoxDecoration(
+            color: blueColorLv2,
+            borderRadius: BorderRadius.circular(6),
+          ),
+        ),
+        const SizedBox(
+          width: 4,
+        ),
+        Container(
+          width: 20,
+          height: 20,
+          decoration: BoxDecoration(
+            color: blueColorLv3,
+            borderRadius: BorderRadius.circular(6),
+          ),
+        ),
+        const SizedBox(
+          width: 4,
+        ),
+        Container(
+          width: 20,
+          height: 20,
+          decoration: BoxDecoration(
+            color: blueColorLv4,
+            borderRadius: BorderRadius.circular(6),
+          ),
+        ),
+        const SizedBox(
+          width: 4,
+        ),
+        Container(
+          width: 20,
+          height: 20,
+          decoration: BoxDecoration(
+            color: blueColorLv5,
+            borderRadius: BorderRadius.circular(6),
+          ),
+        ),
+        const SizedBox(
+          width: 4,
+        ),
+        const Text(
+          "3km",
+          style: TextStyle(
+            fontSize: 12,
+            fontWeight: fontWeightMedium,
+            color: darkGreyColor,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/widgets/walk_log_screen/walking_farm_row_widget.dart
+++ b/lib/widgets/walk_log_screen/walking_farm_row_widget.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:wooyoungsoo/models/recently_walk_log_model.dart';
+import 'package:wooyoungsoo/utils/constants.dart';
+
+/// 최근 산책 기록 밭 위젯
+///
+/// [walkLogs] 최근 산책 기록 리스트
+class WalkingFarmRow extends StatelessWidget {
+  const WalkingFarmRow({
+    super.key,
+    required this.walkLogs,
+  });
+
+  final List<RecentlyWalkLogModel> walkLogs;
+
+  Color getWalkLogColor(double walkedDistance) {
+    if (walkedDistance == 0) {
+      return blueColorLv1;
+    }
+    if (walkedDistance < 1) {
+      return blueColorLv2;
+    }
+    if (walkedDistance < 2) {
+      return blueColorLv3;
+    }
+    if (walkedDistance < 3) {
+      return blueColorLv4;
+    }
+    return blueColorLv5;
+  }
+
+  Color getDayColor(double walkedDistance) {
+    if (walkedDistance < 2) {
+      return darkGreyColor;
+    }
+    return whiteColor;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 270,
+      height: 30,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        itemBuilder: (context, index) {
+          return Container(
+            width: 30,
+            height: 30,
+            decoration: BoxDecoration(
+              color: getWalkLogColor(walkLogs[index].totalWalkedDistance),
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(
+                  walkLogs[index].walkDate.day.toString(),
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: fontWeightBold,
+                    color: getDayColor(walkLogs[index].totalWalkedDistance),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+        separatorBuilder: (context, index) {
+          return const SizedBox(
+            width: 10,
+          );
+        },
+        itemCount: walkLogs.length,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 📌 PR summary
- 산책 기록 페이지 개발

## 💫 Changes
- 산책 기록 페이지 UI 구현
- 최근 30일 산책 기록 조회 및 거리별 색상을 달리해 산책 밭에 표기(레퍼런스 : 깃허브)
- 이번 달 산책 목록 불러오고 연동하는 기능 개발

## 📱 Screenshots
<p align="center"><img src="https://github.com/SWmaestro-14th-somsatang/petdori-FE/assets/65762283/44b5aa33-6b23-47b4-91e8-d6dcc48395b3" height="600px"></p>

## ⚠️ Related Issue
Related [#38 ]

## 📃 ETC  
- UX 측면에서 산책 밭이 아닌 도장을 찍는 형태로 변경하는 것을 고려중..!
